### PR TITLE
`play('foo', cb, 0)` plays sound at default volume instead of no volume

### DIFF
--- a/soundbox.js
+++ b/soundbox.js
@@ -39,7 +39,7 @@ class SoundBox {
 		}
 		
 		var soundInstance = this.sounds[sound_name].cloneNode(true);
-		soundInstance.volume = volume || this.default_volume;
+		soundInstance.volume = typeof volume === 'number' ? volume : this.default_volume;
 		soundInstance.loop = loop;
 		soundInstance.play();
 		this.instances.push(soundInstance);


### PR DESCRIPTION
This sound should not play / should play at default volume. Went for the simpler option of setting the volume to 0 instead of stopping playback, skipping playback would cause the callback to run immediately, unless you waited for the duration of the sound (more complexity). KISS

This is a reasonable use case. In my application, volume is controlled globally by a user setting, where they can set the volume to 100%, 50%, etc. and you guessed it: 0%.